### PR TITLE
Add css to re-align the carousel cards vertically

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -56,37 +56,42 @@ const App = () => {
 
   return (
     <div className='App'>
-    <Routes>
-      <Route path="/" element={
-        <>
-          <h1 tabIndex='0'>Rancid Tomatillos</h1>
-          {error && <h3 className='error'>Oops! Please try again later.</h3>}
-          <Carousel
-            movies={getPopularMovies()}
-            badge='Popular'
-            setMovie={() => {}}
-            allMovies={movies}
-            updateSingleMovie={updateSingleMovie}
-          />
-          <Carousel
-            movies={getRecommendedMovies()}
-            badge='Recommended'
-            setMovie={() => {}}
-            allMovies={movies}
-            updateSingleMovie={updateSingleMovie}
-          />
-          <AllMovies
-            movies={getAllMovies()}
-            badge='All'
-            setMovie={() => {}}
-            allMovies={movies}
-            updateSingleMovie={updateSingleMovie}
-          />
-        </>
-      } />
-      <Route path="/movie/:id" element={<SingleMoviePage />} />
-    </Routes>
-  </div>
+      <Routes>
+        <Route
+          path='/'
+          element={
+            <>
+              <h1 tabIndex='0'>Rancid Tomatillos</h1>
+              {error && (
+                <h3 className='error'>Oops! Please try again later.</h3>
+              )}
+              <Carousel
+                movies={getPopularMovies()}
+                badge='Popular'
+                setMovie={() => {}}
+                allMovies={movies}
+                updateSingleMovie={updateSingleMovie}
+              />
+              <Carousel
+                movies={getRecommendedMovies()}
+                badge='Recommended'
+                setMovie={() => {}}
+                allMovies={movies}
+                updateSingleMovie={updateSingleMovie}
+              />
+              <AllMovies
+                movies={getAllMovies()}
+                badge='All'
+                setMovie={() => {}}
+                allMovies={movies}
+                updateSingleMovie={updateSingleMovie}
+              />
+            </>
+          }
+        />
+        <Route path='/movie/:id' element={<SingleMoviePage />} />
+      </Routes>
+    </div>
   );
 };
 

--- a/src/Components/Card/Card.css
+++ b/src/Components/Card/Card.css
@@ -5,6 +5,15 @@
   position: relative;
 }
 
+.card a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%; 
+  height: 100%; 
+  text-align: center;
+}
+
 .title {
   font-weight: 700;
 }


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes the vertical alignment of the carousel cards. Because they're now links, they needed additional css styling to re-align them vertically.

## Changes
- Add in CSS for our .card classes in Card.css. 

## Related Issues
- Fixes Issue #25 

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
None.
