### PR TITLE
Add loading placeholders on main page

### DIFF
--- a/src/Components/Card/Card.css
+++ b/src/Components/Card/Card.css
@@ -12,6 +12,7 @@
   width: 100%; 
   height: 100%; 
   text-align: center;
+  text-decoration: none;
 }
 
 .card p {

--- a/src/Components/Carousel/Carousel.js
+++ b/src/Components/Carousel/Carousel.js
@@ -4,6 +4,7 @@ import Card from '../Card/Card';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import PropTypes from 'prop-types';
+import LoadingCard from '../Loading Card/LoadingCard';
 
 const MyCarousel = ({
   movies,
@@ -25,6 +26,24 @@ const MyCarousel = ({
       updateSingleMovie={updateSingleMovie}
     />
   ));
+
+  const loadingCards = [
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+  ];
 
   const responsive = {
     desktop: {
@@ -63,7 +82,7 @@ const MyCarousel = ({
         dotListClass='custom-dot-list-style'
         itemClass='carousel-item-padding-40-px'
       >
-        {cardElements}
+        {movies.length > 0 ? cardElements : loadingCards}
       </Carousel>
     </div>
   );

--- a/src/Components/Loading Card/LoadingCard.css
+++ b/src/Components/Loading Card/LoadingCard.css
@@ -14,10 +14,6 @@
   text-align: center;
 }
 
-.card p {
-  width: 170px;
-}
-
 .title {
   font-weight: 700;
 }

--- a/src/Components/Loading Card/LoadingCard.js
+++ b/src/Components/Loading Card/LoadingCard.js
@@ -1,0 +1,26 @@
+import './LoadingCard.css';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
+
+const LoadingCard = () => {
+  const cardStyle = {
+    backgroundColor: '#808080',
+    width: '200px',
+    height: '300px',
+    borderRadius: '10px',
+  };
+
+  return (
+    <div className='card'>
+      <div
+        style={cardStyle}
+        className='poster'
+      ></div>
+      <p className='title' tabIndex='0'>Loading...</p>
+    </div>
+  );
+};
+
+export default LoadingCard;
+

--- a/src/Components/Movies Display/All-Movies.js
+++ b/src/Components/Movies Display/All-Movies.js
@@ -4,6 +4,7 @@ import movieData from '../../Movie-test-data';
 import 'react-multi-carousel/lib/styles.css';
 import './All-Movies.css';
 import PropTypes from 'prop-types';
+import LoadingCard from '../Loading Card/LoadingCard';
 
 const AllMovies = ({
   movies,
@@ -28,29 +29,21 @@ const AllMovies = ({
     />
   ));
 
-  const responsive = {
-    desktop: {
-      breakpoint: { max: 3000, min: 1024 },
-      items: 6,
-    },
-    tablet: {
-      breakpoint: { max: 1024, min: 464 },
-      items: 3,
-    },
-    mobile: {
-      breakpoint: { max: 464, min: 0 },
-      items: 1,
-    },
-  };
-
-  const isMobile = window.innerWidth <= 464;
+  const loadingCards = [
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+    <LoadingCard />,
+  ];
 
   return (
-    <div responsive={responsive} devicetype={isMobile ? 'mobile' : 'desktop'}>
+    <div>
       <hr></hr>
       <h2>{badge} Movies</h2>
       <div className='posterContainer'>
-        <div className='moviePosters'>{cardElements}</div>
+        <div className='moviePosters'>{movies ? cardElements : loadingCards}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
# Pull Request

## Description
This PR makes the loading of the main page a little easier on the eyes by adding in placeholder components.

## Changes
- Add LoadingCard component to Components folder
- Add LoadingCards to Carousels and All Movies section until api call replaces them.

## Related Issues
- Fixes Issue #27 

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
None.
